### PR TITLE
Feature/#81 modal componenet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { useRecoilValue } from 'recoil';
 import { tokenState } from './recoil/atoms/user';
 import GlobalStyle from './components/GlobalStyle';
 import ProfileEditPage from './pages/ProfileEditPage';
+import ConfirmModal from './components/Base/ConfirmModal';
 
 function App() {
   useAxiosInterceptor();
@@ -24,6 +25,7 @@ function App() {
   return (
     <>
       <GlobalStyle />
+      <ConfirmModal />
       <BrowserRouter>
         {/* <Header /> */}
         <Routes>

--- a/src/components/Base/ConfirmModal.tsx
+++ b/src/components/Base/ConfirmModal.tsx
@@ -63,14 +63,14 @@ const Modal = styled.div`
   gap: 3.2rem;
   transform: translate(-50%, -50%);
   padding: 6rem 4.6rem 3rem 4.6rem;
-  background: #ffffff;
+  background: ${COLOR.white};
   box-shadow: 0px 3px 4px rgba(95, 95, 95, 0.24);
   border-radius: 15px;
   box-sizing: border-box;
 `;
 
 const Messasge = styled.div`
-  font-family: 'Noto Sans KR';
+  font-family: 'Noto Sans KR', sans-serif;
   font-style: normal;
   font-weight: 500;
   font-size: 1.6rem;
@@ -88,11 +88,10 @@ const ButtonContainer = styled.div`
 `;
 
 const Button = styled.button<ButtonProps>`
-  font-family: 'Inter';
+  font-family: 'Inter', sans-serif;
   font-style: normal;
   font-weight: 700;
-  font-size: 11px;
-  line-height: 13px;
+  font-size: 1.1rem;
   align-items: center;
   text-align: center;
   letter-spacing: -0.01em;

--- a/src/components/Base/ConfirmModal.tsx
+++ b/src/components/Base/ConfirmModal.tsx
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+import useModal from '../../hooks/useModal';
+import { useRecoilValue } from 'recoil';
+import { modalState } from '../../recoil/atoms/modal';
+
+const ConfirmModal = () => {
+  const modalProps = useRecoilValue(modalState);
+  const { hideModal } = useModal();
+
+  if (!modalProps) return null;
+
+  const { message, handleClose, handleConfirm } = modalProps;
+
+  const onCancel = () => {
+    if (handleClose) handleClose();
+    hideModal();
+  };
+
+  const onConfirm = async () => {
+    if (handleConfirm) await handleConfirm();
+    hideModal();
+  };
+
+  return (
+    <Background>
+      <Container>
+        <div>{message}</div>
+        <button onClick={onCancel}>No</button>
+        <button onClick={onConfirm}>Yes</button>
+      </Container>
+    </Background>
+  );
+};
+
+export default ConfirmModal;
+
+const Background = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const Container = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 0.8rem;
+  background-color: white;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+`;

--- a/src/components/Base/ConfirmModal.tsx
+++ b/src/components/Base/ConfirmModal.tsx
@@ -2,6 +2,11 @@ import styled from 'styled-components';
 import useModal from '../../hooks/useModal';
 import { useRecoilValue } from 'recoil';
 import { modalState } from '../../recoil/atoms/modal';
+import { COLOR } from '../../utils/color';
+
+interface ButtonProps {
+  isConfirm?: boolean;
+}
 
 const ConfirmModal = () => {
   const modalProps = useRecoilValue(modalState);
@@ -22,12 +27,17 @@ const ConfirmModal = () => {
   };
 
   return (
-    <Background>
-      <Container>
-        <div>{message}</div>
-        <button onClick={onCancel}>No</button>
-        <button onClick={onConfirm}>Yes</button>
-      </Container>
+    <Background onClick={hideModal}>
+      <Modal>
+        <Messasge>{message}</Messasge>
+
+        <ButtonContainer>
+          <Button onClick={onCancel}>No</Button>
+          <Button isConfirm={true} onClick={onConfirm}>
+            Yes
+          </Button>
+        </ButtonContainer>
+      </Modal>
     </Background>
   );
 };
@@ -43,13 +53,54 @@ const Background = styled.div`
   background-color: rgba(0, 0, 0, 0.5);
 `;
 
-const Container = styled.div`
+const Modal = styled.div`
+  width: 75%;
   position: fixed;
   top: 50%;
   left: 50%;
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
   transform: translate(-50%, -50%);
-  padding: 0.8rem;
-  background-color: white;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  padding: 6rem 4.6rem 3rem 4.6rem;
+  background: #ffffff;
+  box-shadow: 0px 3px 4px rgba(95, 95, 95, 0.24);
+  border-radius: 15px;
   box-sizing: border-box;
+`;
+
+const Messasge = styled.div`
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 1.6rem;
+  line-height: 2.3rem;
+  letter-spacing: -0.01em;
+  text-align: center;
+
+  color: ${COLOR.text};
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 0 1rem;
+`;
+
+const Button = styled.button<ButtonProps>`
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 13px;
+  align-items: center;
+  text-align: center;
+  letter-spacing: -0.01em;
+  width: 7rem;
+
+  color: ${COLOR.white};
+  background-color: ${({ isConfirm }) =>
+    isConfirm ? COLOR.green : COLOR.lightGray};
+  border-radius: 23.5px;
+  padding: 1rem;
 `;

--- a/src/components/Base/ConfirmModal.tsx
+++ b/src/components/Base/ConfirmModal.tsx
@@ -32,9 +32,9 @@ const ConfirmModal = () => {
         <Messasge>{message}</Messasge>
 
         <ButtonContainer>
-          <Button onClick={onCancel}>No</Button>
+          <Button onClick={onCancel}>NO</Button>
           <Button isConfirm={true} onClick={onConfirm}>
-            Yes
+            YES
           </Button>
         </ButtonContainer>
       </Modal>

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,18 @@
+import { useRecoilState } from 'recoil';
+import { ModalProps, modalState } from '../recoil/atoms/modal';
+
+const useModal = () => {
+  const [modal, setModal] = useRecoilState(modalState);
+
+  const showModal = (modalProps: ModalProps) => {
+    setModal(modalProps);
+  };
+
+  const hideModal = () => {
+    setModal(null);
+  };
+
+  return { modal, showModal, hideModal };
+};
+
+export default useModal;

--- a/src/recoil/atoms/modal.ts
+++ b/src/recoil/atoms/modal.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+
+export type ModalProps = {
+  message: string;
+  handleClose?: (...arg: any[]) => any;
+  handleConfirm?: (...arg: any[]) => any;
+};
+
+export const modalState = atom<ModalProps | null>({
+  key: 'modalState',
+  default: null,
+});


### PR DESCRIPTION
## 📌 이슈 번호

#81 

## 👩‍💻 작업 내용

* 모달이 필요할 때 마다 모달 컴포넌트를 import 하는 것이 불편하여 글로벌한 모달 컴포넌트를 구현했습니다.
* recoil 로 관리하는 modalState를 기반으로 모달이 렌더링 됩니다.

<img width="207" alt="image" src="https://user-images.githubusercontent.com/48359052/212542312-b935ec39-440e-4423-9ab3-c343ba2c2e19.png">


```typescript
type modalState = {
  message: string; // 모달에 표시할 텍스트
  handleClose?: (...arg: any[]) => any; // 취소 버튼을 눌렀을 때 호출할 콜백 함수
  handleConfirm?: (...arg: any[]) => any; // 확인 버튼을 눌렀을 떄 호출할 콜백 함수
}
```


**사용방법 예시**

```typescript
const { showModal } = useModal();

const onSubmit = () => {
  showModal({
    message: '정말 진행하시겠습니까?',
    handleConfirm: () => {
      console.log('click confirm button!')
  });
};

return (
  <>
    <button onClick={onSubmit}>Submit</button>
  <>
)
```
