### PR TITLE
fix/163 notification 401

### DIFF
--- a/src/components/Notification/NotificationList.tsx
+++ b/src/components/Notification/NotificationList.tsx
@@ -1,19 +1,38 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import Notification from './Notification';
-import useNotification from '../../hooks/useNotification';
 import { useRecoilState } from 'recoil';
 import { userState } from '../../recoil/atoms/user';
 import { COLOR } from '../../utils/color';
-import { seenNotification } from '../../utils/api/notification';
+import {
+  getNotifications,
+  seenNotifications,
+} from '../../utils/api/notification';
+import { NotificationResponse } from '../../types/response';
+import { ERROR_MESSAGES } from '../../utils/messages';
+import useToast from '../../hooks/useToast';
 
 const NotificationList = () => {
   const [user] = useRecoilState(userState);
-  const { notifications } = useNotification();
+  const { showToast } = useToast();
+
+  const [notifications, setNotifications] = useState<NotificationResponse[]>(
+    []
+  );
+
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const notifications = await getNotifications();
+      setNotifications(notifications);
+    } catch (error) {
+      console.error(error);
+      showToast({ message: ERROR_MESSAGES.GET_ERROR('알림을') });
+    }
+  }, [showToast]);
 
   const fetchSeenNotifications = useCallback(async () => {
     try {
-      await seenNotification();
+      await seenNotifications();
     } catch (error) {
       console.error(error);
     }
@@ -21,7 +40,8 @@ const NotificationList = () => {
 
   useEffect(() => {
     fetchSeenNotifications();
-  }, [fetchSeenNotifications]);
+    fetchNotifications();
+  }, [fetchSeenNotifications, fetchNotifications]);
 
   return (
     <List>

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -3,9 +3,12 @@ import { getNotification } from '../utils/api/notification';
 import { NotificationResponse } from '../types/response';
 import useToast from './useToast';
 import { ERROR_MESSAGES } from '../utils/messages';
+import { useRecoilValue } from 'recoil';
+import { tokenState } from '../recoil/atoms/user';
 
 const useNotification = () => {
   const [notifications, setNotification] = useState<NotificationResponse[]>([]);
+  const token = useRecoilValue(tokenState);
 
   const isSeen = useMemo(() => {
     const seenResults = notifications.map((v) => v.seen);
@@ -28,8 +31,9 @@ const useNotification = () => {
   }, [showToast]);
 
   useEffect(() => {
+    if (!token) return;
     fetchNotification();
-  }, [fetchNotification]);
+  }, [fetchNotification, token]);
 
   return {
     isSeen,

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,8 +1,11 @@
 import { useState, useMemo, useEffect } from 'react';
 import { getNotifications } from '../utils/api/notification';
 import { NotificationResponse } from '../types/response';
+import { useRecoilValue } from 'recoil';
+import { tokenState } from '../recoil/atoms/user';
 
 const useCheckNotifications = () => {
+  const token = useRecoilValue(tokenState);
   const [notifications, setNotifications] = useState<NotificationResponse[]>(
     []
   );
@@ -17,13 +20,14 @@ const useCheckNotifications = () => {
 
   useEffect(() => {
     const handleInterval = setInterval(async () => {
+      if (!token) return;
       const notifications = await getNotifications();
       setNotifications(notifications);
     }, 5000);
     return () => {
       clearInterval(handleInterval);
     };
-  }, []);
+  }, [token]);
 
   return {
     isSeen,

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,14 +1,11 @@
-import { useState, useCallback, useMemo, useEffect } from 'react';
-import { getNotification } from '../utils/api/notification';
+import { useState, useMemo, useEffect } from 'react';
+import { getNotifications } from '../utils/api/notification';
 import { NotificationResponse } from '../types/response';
-import useToast from './useToast';
-import { ERROR_MESSAGES } from '../utils/messages';
-import { useRecoilValue } from 'recoil';
-import { tokenState } from '../recoil/atoms/user';
 
-const useNotification = () => {
-  const [notifications, setNotification] = useState<NotificationResponse[]>([]);
-  const token = useRecoilValue(tokenState);
+const useCheckNotifications = () => {
+  const [notifications, setNotifications] = useState<NotificationResponse[]>(
+    []
+  );
 
   const isSeen = useMemo(() => {
     const seenResults = notifications.map((v) => v.seen);
@@ -18,28 +15,19 @@ const useNotification = () => {
     return true;
   }, [notifications]);
 
-  const { showToast } = useToast();
-
-  const fetchNotification = useCallback(async () => {
-    try {
-      const notifications = await getNotification();
-      setNotification(notifications);
-    } catch (error) {
-      setNotification([]);
-      showToast({ message: ERROR_MESSAGES.GET_ERROR('알림을') });
-    }
-  }, [showToast]);
-
   useEffect(() => {
-    if (!token) return;
-    fetchNotification();
-  }, [fetchNotification, token]);
+    const handleInterval = setInterval(async () => {
+      const notifications = await getNotifications();
+      setNotifications(notifications);
+    }, 5000);
+    return () => {
+      clearInterval(handleInterval);
+    };
+  }, []);
 
   return {
     isSeen,
-    notifications,
-    fetchNotification,
   };
 };
 
-export default useNotification;
+export default useCheckNotifications;

--- a/src/utils/api/notification.ts
+++ b/src/utils/api/notification.ts
@@ -4,12 +4,12 @@ interface LikeParam {
   (type: string, dataId: string, userId: string, postId: string | null): void;
 }
 
-export const getNotification = async () => {
+export const getNotifications = async () => {
   const { data } = await axiosInstance.get(`/notifications`);
   return data;
 };
 
-export const seenNotification = async () => {
+export const seenNotifications = async () => {
   await axiosInstance.put(`/notifications/seen`);
 };
 


### PR DESCRIPTION
## 📌 이슈 번호

#163 

## 👩‍💻 작업 내용

헤더 컴포넌트가 렌더링되면 무조건 notification API를 호출하는 이슈를 수정했습니다.
hook으로 분리해두신 useNotification이 호출되면서 발생하는 이슈였네요.  @dazzel3 

기존 hook 에서 필요없는 내용을 지우고, setInterval로 알람 상태를 조회하도록 수정했습니다.