### PR TITLE
Bugfix/#248 searchbar state preserve

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -15,6 +15,7 @@ import {
   PostEditPage,
   ProfileEditPage,
 } from './pages';
+import SearchbarLayout from './components/Layout/SearchbarLayout';
 
 const Router = () => {
   const token = useRecoilValue(tokenState);
@@ -22,7 +23,26 @@ const Router = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path={ROUTES.HOME} element={<HomePage />} />
+        {/* with searchbar */}
+        <Route element={<SearchbarLayout />}>
+          <Route path={ROUTES.HOME} element={<HomePage />} />
+          <Route path={ROUTES.SEARCH} element={<SearchPage />} />
+          <Route path={ROUTES.PROFILE_ME_LIKES} element={<MyLikesPage />} />
+          <Route path={ROUTES.NOTIFICATION} element={<NotificationsPage />} />
+          <Route path={ROUTES.PROFILE_DETAIL} element={<ProfilePage />} />
+          <Route path={ROUTES.POSTS_DETAIL} element={<PostPage />} />
+          <Route
+            path={ROUTES.PROFILE_ME_EDIT}
+            element={
+              !token ? (
+                <Navigate replace to={ROUTES.PROFILE_ME} />
+              ) : (
+                <ProfileEditPage />
+              )
+            }
+          />
+        </Route>
+        {/* without searchbar */}
         <Route
           path={ROUTES.LOGIN}
           element={
@@ -35,23 +55,8 @@ const Router = () => {
             token ? <Navigate replace to={ROUTES.HOME} /> : <SignUpPage />
           }
         />
-        <Route path={ROUTES.SEARCH} element={<SearchPage />} />
         <Route path={ROUTES.POSTS_NEW} element={<PostEditPage />} />
-        <Route path={ROUTES.POSTS_DETAIL} element={<PostPage />} />
         <Route path={ROUTES.POSTS_EDIT} element={<PostEditPage />} />
-        <Route path={ROUTES.PROFILE_DETAIL} element={<ProfilePage />} />
-        <Route path={ROUTES.PROFILE_ME_LIKES} element={<MyLikesPage />} />
-        <Route
-          path={ROUTES.PROFILE_ME_EDIT}
-          element={
-            !token ? (
-              <Navigate replace to={ROUTES.PROFILE_ME} />
-            ) : (
-              <ProfileEditPage />
-            )
-          }
-        />
-        <Route path={ROUTES.NOTIFICATION} element={<NotificationsPage />} />
         <Route path={ROUTES.NOT_FOUND} element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/Layout/SearchbarLayout.tsx
+++ b/src/components/Layout/SearchbarLayout.tsx
@@ -1,0 +1,13 @@
+import Header from '../Header/Header';
+import { Outlet } from 'react-router-dom';
+
+const SearchbarLayout = () => {
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
+};
+
+export default SearchbarLayout;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Post from '../components/Post/Post';
-import Header from '../components/Header/Header';
 import { getPosts } from '../utils/api/post';
 import useIntersectionObserver from '../hooks/useIntersectionObserver';
 import { getChannelInfo } from '../utils/api/channel';
@@ -66,7 +65,6 @@ const HomePage = () => {
 
   return (
     <Container>
-      <Header />
       <List>
         {posts.map((post) => (
           <ListItem key={post._id}>

--- a/src/pages/MyLikesPage.tsx
+++ b/src/pages/MyLikesPage.tsx
@@ -5,7 +5,6 @@ import DetailHeader from '../components/Header/DetailHeader';
 import { userState } from '../recoil/atoms/user';
 import { getAllPosts } from '../utils/api/post';
 import styled from 'styled-components';
-import Header from '../components/Header/Header';
 import Spinner from '../components/Base/Spinner';
 import type { PostResponse } from '../types/api/post';
 
@@ -39,7 +38,6 @@ const MyLikesPage = () => {
 
   return (
     <Container>
-      <Header />
       <DetailHeader name="내가 좋아한 그라운드" isButton={false} />
       <Wrapper>
         {posts.map((post) => (

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,12 +1,10 @@
 import NotificationList from '../components/Notification/NotificationList';
 import DetailHeader from '../components/Header/DetailHeader';
 import styled from 'styled-components';
-import Header from '../components/Header/Header';
 
 const NotificationsPage = () => {
   return (
     <Container>
-      <Header />
       <DetailHeader name="알림" isButton={false} />
       <NotificationList />
     </Container>

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Comment from '../components/Comment/Comment';
 import CommentInput from '../components/Comment/CommentInput';
-import Header from '../components/Header/Header';
 import Post from '../components/Post/Post';
 import COLORS from '../utils/colors';
 import { getPost } from '../utils/api/post';
@@ -55,7 +54,6 @@ const PostPage = () => {
 
   return (
     <Container>
-      <Header />
       {post && (
         <Wrapper>
           <Post {...post} checkIsMine={true} isDetailPage={true} />

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -1,12 +1,10 @@
 import styled from 'styled-components';
 import DetailHeader from '../components/Header/DetailHeader';
-import Header from '../components/Header/Header';
 import ProfileEditForm from '../components/Profile/ProfileEditForm';
 
 const ProfileEditPage = () => {
   return (
     <>
-      <Header />
       <LoginPageContainer>
         <DetailHeader isButton={false} />
         <ProfileEditForm />

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -11,7 +11,6 @@ import { userState } from '../recoil/atoms/user';
 import { getUser } from '../utils/api/user';
 import COLORS from '../utils/colors';
 import Icon from '../components/Base/Icon';
-import Header from '../components/Header/Header';
 import ROUTES from '../utils/routes';
 import Image from '../components/Base/Image';
 import { queryLowImage } from '../utils/image';
@@ -75,7 +74,6 @@ const ProfilePage = () => {
 
   return (
     <>
-      <Header />
       <Wrapper>
         <DetailHeader name="" isButton={false}>
           {userId === 'me' ? (

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Spinner from '../components/Base/Spinner';
-import Header from '../components/Header/Header';
 import Post from '../components/Post/Post';
 import UserItem from '../components/User/UserItem';
 import axiosInstance from '../utils/axios';
@@ -57,7 +56,6 @@ const SearchPage = () => {
 
   return (
     <Container>
-      <Header />
       {searchParams.get('type') === 'users' ? (
         <List>
           {userResult.map((user) => (


### PR DESCRIPTION
## 📌 이슈 번호

#248 

## 👩‍💻 작업 내용

민종님이 발견하신 검색바 상태값이 페이지 이동시 사라지는 문제를 해결하였습니다.
- Header 컴포넌트의 엘리먼트 위치를 유지하는 아이디어로 state를 보존하였습니다.
- react-router-dom의 Outlet 컴포넌트를 활용하여 레이아웃을 구현하였습니다.
- 중복으로 들어있던 Header 컴포넌트를 제거하였습니다.

빠진 부분이나 추가해야될 내용이 있다면 리뷰에 남겨주세요!

https://github.com/prgrms-fe-devcourse/FEDC3_DigDigDeep_Yuri/assets/82329983/de52d6f6-4c24-4067-b8b7-c0d8208f2f3d

